### PR TITLE
Avoid adding to closed stream

### DIFF
--- a/lib/src/wallet_connect/sink_transform.dart
+++ b/lib/src/wallet_connect/sink_transform.dart
@@ -34,7 +34,9 @@ abstract class SinkTransformer<S, T> implements Sink<T> {
 
   @override
   void close() {
-    _sink?.close();
+    final sink = _sink;
+    _sink = null;
+    sink?.close();
   }
 
   FutureOr<S> doTransform(T data);


### PR DESCRIPTION
If the sink is closed before an async add is complete, then an exception is thrown.

```
@override
void add(T data) {
  final transformed = doTransform(data);
  if (transformed is Future<S>) {
    transformed.then((value) => _sink?.add(value));
  } else {
    _sink?.add(transformed);
  }
}
  ```