### PR TITLE
Added additional fields to SignTransactionData 

### DIFF
--- a/lib/proto.dart
+++ b/lib/proto.dart
@@ -17,6 +17,7 @@ export 'package:provenance_dart/src/proto/proto_gen/cosmos/base/abci/v1beta1/abc
 
 export 'package:fixnum/fixnum.dart' show Int64;
 export 'package:protobuf/protobuf.dart' show GeneratedMessage;
+export 'package:grpc/grpc.dart' show GrpcError;
 
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/authz/v1beta1/tx.pb.dart';
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/bank/v1beta1/tx.pb.dart';
@@ -25,8 +26,10 @@ import 'package:provenance_dart/src/proto/proto_gen/cosmos/distribution/v1beta1/
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/evidence/v1beta1/tx.pb.dart';
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/feegrant/v1beta1/tx.pb.dart';
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/gov/v1/tx.pb.dart';
-import 'package:provenance_dart/src/proto/proto_gen/cosmos/group/v1/tx.pb.dart' as group;
-import 'package:provenance_dart/src/proto/proto_gen/cosmos/nft/v1beta1/tx.pb.dart' as nft;
+import 'package:provenance_dart/src/proto/proto_gen/cosmos/group/v1/tx.pb.dart'
+    as group;
+import 'package:provenance_dart/src/proto/proto_gen/cosmos/nft/v1beta1/tx.pb.dart'
+    as nft;
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/slashing/v1beta1/tx.pb.dart';
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/staking/v1beta1/tx.pb.dart';
 import 'package:provenance_dart/src/proto/proto_gen/cosmos/tx/v1beta1/service.pb.dart';

--- a/lib/src/proto/pb_client.dart
+++ b/lib/src/proto/pb_client.dart
@@ -279,8 +279,12 @@ class PbClient {
   /// estimate the abount of gas required to execute a transaction.
   ///
   Future<GasEstimate> estimateTransactionFees(
-      TxBody transactionBody, Iterable<keys.IPubKey> signers,
-      {double gasAdjustment = defaultFeeAdjustment, String? feeGranter}) async {
+    TxBody transactionBody,
+    Iterable<keys.IPubKey> signers, {
+    double gasAdjustment = defaultFeeAdjustment,
+    String? feeGranter,
+    String? feePayer,
+  }) async {
     final signerInfos = await Future.wait(signers.map((publicKey) async {
       final account = await getBaseAccount(publicKey.address);
 
@@ -289,7 +293,10 @@ class PbClient {
 
     final authInfo = AuthInfo(
         fee: Fee(
-            amount: <Coin>[], gasLimit: fixnum.Int64(0), granter: feeGranter),
+            amount: <Coin>[],
+            gasLimit: fixnum.Int64(0),
+            granter: feeGranter,
+            payer: feePayer),
         signerInfos: signerInfos);
 
     // generate placeholders for the actual signatures.
@@ -324,18 +331,28 @@ class PbClient {
   /// it to the blockchain.
   ///
   Future<RawTxResponsePair> estimateAndBroadcastTransaction(
-      TxBody transactionBody, List<keys.IPrivKey> signers,
-      {double gasAdjustment = defaultFeeAdjustment, String? feeGranter}) async {
+    TxBody transactionBody,
+    List<keys.IPrivKey> signers, {
+    double gasAdjustment = defaultFeeAdjustment,
+    String? feeGranter,
+    String? feePayer,
+  }) async {
     final publicKeys = signers.map((e) => e.publicKey);
 
     final gasEstimate = await estimateTransactionFees(
-        transactionBody, publicKeys,
-        gasAdjustment: gasAdjustment, feeGranter: feeGranter);
+      transactionBody,
+      publicKeys,
+      gasAdjustment: gasAdjustment,
+      feeGranter: feeGranter,
+      feePayer: feePayer,
+    );
 
     final fee = Fee(
-        amount: gasEstimate.feeCalculated,
-        gasLimit: fixnum.Int64(gasEstimate.limit),
-        granter: feeGranter);
+      amount: gasEstimate.feeCalculated,
+      gasLimit: fixnum.Int64(gasEstimate.limit),
+      granter: feeGranter,
+      payer: feePayer,
+    );
 
     return broadcastTransaction(transactionBody, signers, fee);
   }


### PR DESCRIPTION
i added fee payer, memo, timeoutHeight, non critical extension options, and critical extension options to the signTransactionData object. I added the feePayer field to the estimate and broadcast methods. NOTE: the feePayer must also sign the transaction.